### PR TITLE
Rename plugin class to not conflict with namespace

### DIFF
--- a/content/SilksongPlugin/.template.config/template.json
+++ b/content/SilksongPlugin/.template.config/template.json
@@ -47,6 +47,13 @@
         }
       ]
     },
+    "polysharp": {
+      "type": "parameter",
+      "datatype": "bool",
+      "displayName": "Enable PolySharp?",
+      "description": "Whether to enable PolySharp to polyfill newer language features that do not require runtime support.",
+      "defaultValue": "false"
+    },
     "unity-version": {
       "type": "generated",
       "replaces": "UnityVersion",
@@ -61,12 +68,12 @@
         ]
       }
     },
-    "polysharp": {
-      "type": "parameter",
-      "datatype": "bool",
-      "displayName": "Enable PolySharp?",
-      "description": "Whether to enable PolySharp to polyfill newer language features that do not require runtime support.",
-      "defaultValue": "false"
+    "safe-source-name": {
+      // I think it's really really cool that value forms of sourceName are not applied to file names by default
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "safe_name",
+      "fileRename": "SilksongPlugin__1"
     }
   },
   "postActions": [

--- a/content/SilksongPlugin/SilksongPlugin__1Plugin.cs
+++ b/content/SilksongPlugin/SilksongPlugin__1Plugin.cs
@@ -4,7 +4,7 @@ namespace SilksongPlugin._1;
 
 // TODO - adjust the plugin guid as needed
 [BepInAutoPlugin(id: "io.github.silksongplugin__1")]
-public partial class SilksongPlugin__1 : BaseUnityPlugin
+public partial class SilksongPlugin__1Plugin : BaseUnityPlugin
 {
     private void Awake()
     {


### PR DESCRIPTION
Tested locally. This also fixes an issue where file name of the plugin class may not match the class name depending on the input name.

With ` dotnet new silksongplugin -gv 1.0.28561 -p -n "Test Template"` I got the following outputs:

* File name: Test_TemplatePlugin.cs
* Class name: Test_TemplatePlugin