### PR TITLE
Update gamelibs to 1.1.0, version to 1.2.0

### DIFF
--- a/Silksong.Modding.Templates.csproj
+++ b/Silksong.Modding.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Silksong.Modding.Templates</PackageId>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>BadMagic</Authors>
     <Description>Templates for creating mods for Hollow Knight: Silksong</Description>
     <PackageTags>silksong modding bepinex5</PackageTags>

--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Hamunii.BepInEx.AutoPlugin" Version="2.0.1" PrivateAssets="all"/>
     <PackageReference Include="UnityEngine.Modules" Version="UnityVersion" IncludeAssets="compile" />
     <!--If you're unable resolve this dependency, check that you're using the nuget v3 package feed instead of v2.-->
-    <PackageReference Include="Silksong.GameLibs" Version="1.0.2-silksongSilksongVersion"/>
+    <PackageReference Include="Silksong.GameLibs" Version="1.1.0-silksongSilksongVersion"/>
   </ItemGroup>
 
   <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongFolder)' != ''">


### PR DESCRIPTION
As the title says. Should wait to merge until the gamelibs versions are available to prevent people's builds from failing, currently they're indexing.