### PR TITLE
Add support for 1.0.28714

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ then run the following:
 > dotnet new silksongplugin -gv SilksongGameVersion
 ```
 
-As of Sept 22 2025, the latest Silksong version is `1.0.28650`.
+As of Oct 3 2025, the latest Silksong version is `1.0.28714`.
 
 Use `dotnet new silksongplugin --help` to see additional options.

--- a/Silksong.Modding.Templates.csproj
+++ b/Silksong.Modding.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Silksong.Modding.Templates</PackageId>
-    <PackageVersion>1.2.3</PackageVersion>
+    <PackageVersion>1.2.4</PackageVersion>
     <Authors>BadMagic</Authors>
     <Description>Templates for creating mods for Hollow Knight: Silksong</Description>
     <PackageTags>silksong modding bepinex5</PackageTags>

--- a/content/SilksongPlugin/.template.config/template.json
+++ b/content/SilksongPlugin/.template.config/template.json
@@ -34,6 +34,10 @@
       "isRequired": true,
       "choices": [
         {
+          "choice": "1.0.28714",
+          "description": "Undocumented patch for all platforms. Contains the patch for CVE-2025-59489 on Windows and Mac. Released Sept 24 2025/patched Oct 3."
+        },
+        {
           "choice": "1.0.28650",
           "description": "Second real bugfix patch. Released Sept 22 2025."
         },
@@ -66,7 +70,7 @@
         "dataType": "string",
         "cases": [
           {
-            "condition": "game-version == '1.0.28324' || game-version == '1.0.28497' || game-version == '1.0.28561' || game-version == '1.0.28650'",
+            "condition": "game-version == '1.0.28324' || game-version == '1.0.28497' || game-version == '1.0.28561' || game-version == '1.0.28650' || game-version == '1.0.28714'",
             "value": "6000.0.50"
           }
         ]


### PR DESCRIPTION
### Summary of Changes

Adds support for 1.0.28714.

### Checklist

* [x] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [x] I have updated the readme to reflect the latest release information.
  * [x] I have updated template.json to include the new game version.
  * [x] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  