### PR TITLE
Make PathMap conditional for release target

### DIFF
--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -15,8 +15,8 @@
     </RestoreAdditionalProjectSources>
     <!--Allow access of private members at runtime.-->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Makes paths in the .pdb show up as `source/...` instead of potentially having usernames-->
-    <PathMap>$(MSBuildProjectDirectory)=source</PathMap>
+    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Summary of Changes

Makes PathMap conditional on release target so that breakpoints will work for local debugging. Also changed the mapped path to `/` and updated the doc comments accordingly

### Checklist

* [ ] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated the readme to reflect the latest release information.
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  