### PR TITLE
Add support for 1.0.28891 and latest alias

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@ Provide a quick summary of the change. What problem is being addressed and how?
 
 * [ ] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
 * If updating to support a new Silksong version only:
-  * [ ] I have updated the readme to reflect the latest release information.
   * [ ] I have updated template.json to include the new game version.
   * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
   

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Usage: navigate to the folder you want to create a mod, then run the following:
 ```
 > dotnet new install Silksong.Modding.Templates
 
-> dotnet new silksongplugin -gv SilksongGameVersion
+> dotnet new silksongplugin
 ```
 
-As of Oct 3 2025, the latest Silksong version is `1.0.28714`.
+By default, the template automatically targets the latest available version of the game. If you want to make mods
+specifically targeting an older version of the game, you can use the `-gv` flag to specify the version.
 
 Use `dotnet new silksongplugin --help` to see additional options.

--- a/Silksong.Modding.Templates.csproj
+++ b/Silksong.Modding.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Silksong.Modding.Templates</PackageId>
-    <PackageVersion>1.2.4</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
     <Authors>BadMagic</Authors>
     <Description>Templates for creating mods for Hollow Knight: Silksong</Description>
     <PackageTags>silksong modding bepinex5</PackageTags>

--- a/content/SilksongPlugin/.template.config/template.json
+++ b/content/SilksongPlugin/.template.config/template.json
@@ -30,9 +30,17 @@
       "dataType": "choice",
       "replaces": "SilksongVersion",
       "displayName": "Game Version",
-      "description": "The version of Silksong being modded.",
-      "isRequired": true,
+      "description": "The version of Silksong being modded. Most mods should choose latest, but mods that are specifically targeting an older version can specify that version.",
+      "defaultValue": "latest",
       "choices": [
+        {
+          "choice": "latest",
+          "description": "Automatically target the latest version of the game."
+        },
+        {
+          "choice": "1.0.28891",
+          "description": "Bugfix and balance patch. Released Oct 13 2025."
+        },
         {
           "choice": "1.0.28714",
           "description": "Undocumented patch for all platforms. Contains the patch for CVE-2025-59489 on Windows and Mac. Released Sept 24 2025/patched Oct 3."
@@ -70,7 +78,12 @@
         "dataType": "string",
         "cases": [
           {
-            "condition": "game-version == '1.0.28324' || game-version == '1.0.28497' || game-version == '1.0.28561' || game-version == '1.0.28650' || game-version == '1.0.28714'",
+            "condition": "game-version == 'latest'",
+            "value": "6000.0.50"
+          },
+          {
+            // default case. We'll worry about newer unity versions as they happen
+            "condition": "",
             "value": "6000.0.50"
           }
         ]

--- a/content/SilksongPlugin/Directory.Build.props
+++ b/content/SilksongPlugin/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!--These properties will control the generated plugin info. Version is also used by various parts of the build system.-->
+    <AssemblyTitle>SilksongPlugin.1</AssemblyTitle>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+</Project>

--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -13,16 +13,11 @@
     <RestoreAdditionalProjectSources>
       https://nuget.bepinex.dev/v3/index.json
     </RestoreAdditionalProjectSources>
+    <RestorePackagesWithLockFile Condition="'$(game-version)' == 'latest'">True</RestorePackagesWithLockFile>
     <!--Allow access of private members at runtime.-->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!--These properties will control the generated plugin info. Version is also used by various parts of the build system.-->
-    <AssemblyTitle>SilksongPlugin.1</AssemblyTitle>
-    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,7 +26,8 @@
     <PackageReference Include="Hamunii.BepInEx.AutoPlugin" Version="2.0.1" PrivateAssets="all"/>
     <PackageReference Include="UnityEngine.Modules" Version="UnityVersion" IncludeAssets="compile" />
     <!--If you're unable resolve this dependency, check that you're using the nuget v3 package feed instead of v2.-->
-    <PackageReference Include="Silksong.GameLibs" Version="1.1.0-silksongSilksongVersion"/>
+    <PackageReference Include="Silksong.GameLibs" Version="*-*" PrivateAssets="all" Condition="'$(game-version)' == 'latest'"/>
+    <PackageReference Include="Silksong.GameLibs" Version="1.1.0-silksongSilksongVersion" PrivateAssets="all" Condition="'$(game-version)' != 'latest'"/>
   </ItemGroup>
 
   <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(SilksongFolder)' != ''">


### PR DESCRIPTION
### Summary of Changes

* Enhanced template.json with a default `latest` game version, added a new game version choice, and adjusted generator accordingly. Updated SilksongPlugin.1.csproj to conditionally manage dependencies and enable lock files for `latest` game version.
* Added Directory.Build.props to make the plugin configuration props more visible.
* README now explains default targeting of the latest game version. Updated pull request template to remove requirement to update readme version and provides instructions for specifying older versions. 
* Bumped package version to 1.3.0 in Silksong.Modding.Templates.csproj.

### Checklist

* [x] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [x] I have updated the readme to reflect the latest release information.
  * [x] I have updated template.json to include the new game version.
  * [x] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  