### PR TITLE
Suppress MSB3270 warning in project file

### DIFF
--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -13,6 +13,8 @@
     <RestoreAdditionalProjectSources>
       https://nuget.bepinex.dev/v3/index.json
     </RestoreAdditionalProjectSources>
+    <!-- Ignore warning about processor architecture mismatch with PlayMaker ConditionalExpression -->
+    <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <RestorePackagesWithLockFile Condition="'$(game-version)' == 'latest'">True</RestorePackagesWithLockFile>
     <!--Allow access of private members at runtime.-->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
### Summary of Changes

Updated the `<NoWarn>` property in `SilksongPlugin.1.csproj` to include MSB3270. Added a comment to explain the suppression of the MSB3270 warning related to processor architecture mismatch with PlayMaker ConditionalExpression.

### Checklist

N/A, quick patch will go into next release PR

* [ ] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  