### PR TITLE
Add Microsoft.Unity.Analyzers

### DIFF
--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="HarmonyX" Version="2.9.0" />
     <PackageReference Include="Hamunii.BepInEx.AutoPlugin" Version="2.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.25.0" PrivateAssets="all" />
     <PackageReference Include="UnityEngine.Modules" Version="UnityVersion" IncludeAssets="compile" />
     <!--If you're unable resolve this dependency, check that you're using the nuget v3 package feed instead of v2.-->
     <PackageReference Include="Silksong.GameLibs" Version="*-*" PrivateAssets="all" Condition="'$(game-version)' == 'latest'" />


### PR DESCRIPTION
### Summary of Changes

Add the `Microsoft.Unity.Analyzers` package, which provide Unity specific linting.

### Checklist

* [x] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  