### PR TITLE
Update PR template for clearer versioning guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,10 @@ Provide a quick summary of the change. What problem is being addressed and how?
 
 ### Checklist
 
-* [ ] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
+* No change is too small for a release, so pick one:
+  * [ ] I have updated the package version following semantic versioning
+  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
+  * [ ] This PR does not change the template content/config.
 * If updating to support a new Silksong version only:
   * [ ] I have updated template.json to include the new game version.
   * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.


### PR DESCRIPTION

### Summary of Changes

Revised the pull request template to clarify the requirements for updating the package version. Added a new section to emphasize that no change is too small for a release, requiring contributors to address version updates or justify not updating. The checklist now includes options for handling version updates: updating the version, linking to a WIP change, or confirming no template changes. Maintained the existing checklist for supporting new Silksong versions to ensure compatibility.

### Checklist

* [x] I have updated the package version following semantic versioning OR this PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  