### PR TITLE
Improve default repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are a few scenarios where the template makes a best guess. The following t
 in some scenarios:
 
 - `website_url` in thunderstore.toml and `RepositoryUrl` in the .csproj assume that you are using GitHub and that the
-  repository name is the safe class name of your project. If either is not the case, you will have to update these URLs.
+  repository name is the name of your project. If either is not the case, you will have to update these URLs.
 - Most metadata contained in thunderstore.toml is placeholder. You will have to update it before publishing your mod.
 - The Thunderstore icon should minimally be updated to contain your mod name; there is space available for top/bottom text.
   Of course, you can also replace it with any .png of the same size.

--- a/Silksong.Modding.Templates.csproj
+++ b/Silksong.Modding.Templates.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Silksong.Modding.Templates</PackageId>
-    <PackageVersion>2.0.0-alpha.1</PackageVersion>
+    <PackageVersion>2.0.0-alpha.2</PackageVersion>
     <Authors>BadMagic</Authors>
     <Description>Templates for creating mods for Hollow Knight: Silksong</Description>
     <PackageTags>silksong modding bepinex5</PackageTags>

--- a/content/SilksongPlugin/SilksongPlugin.1.csproj
+++ b/content/SilksongPlugin/SilksongPlugin.1.csproj
@@ -24,7 +24,7 @@
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <RepositoryUrl>https://github.com/UserName/SilksongPlugin__1</RepositoryUrl>
+    <RepositoryUrl>https://github.com/UserName/SilksongPlugin.1</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" />

--- a/content/SilksongPlugin/thunderstore/thunderstore.toml
+++ b/content/SilksongPlugin/thunderstore/thunderstore.toml
@@ -8,7 +8,7 @@ namespace = "ThunderstoreUserName"
 description = "Example mod description"
 
 # Replace this with a correct repo URL if the default is not accurate
-websiteUrl = "https://github.com/UserName/SilksongPlugin__1"
+websiteUrl = "https://github.com/UserName/SilksongPlugin.1"
 containsNsfwContent = false
 
 


### PR DESCRIPTION
### Summary of Changes

When doing repo setup for some core mods I found that names with dots were super annoying because they replace with `_`, this is actually fine in some places like the thunderstore name where _ is replaced with space but it's not great for repo URLs. The initial motivation to use safe name was to cover people who may try to put spaces in their names but I think it is fine to assume in most cases the project name/folder name is the same as the repo name which cannot contain spaces anyway, so I opted to go to the identity form.

### Checklist

* No change is too small for a release, so pick one:
  * [X] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [ ] This PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  