### PR TITLE
Change Awake method to Start

### DIFF
--- a/Silksong.Modding.Templates/content/SilksongPlugin/Plugin__1Plugin.cs
+++ b/Silksong.Modding.Templates/content/SilksongPlugin/Plugin__1Plugin.cs
@@ -6,7 +6,7 @@ namespace Silksong.Plugin._1;
 [BepInAutoPlugin(id: "io.github.username.plugin__1")]
 public partial class Plugin__1Plugin : BaseUnityPlugin
 {
-    private void Awake()
+    private void Start()
     {
         // Put your initialization logic here
         Logger.LogInfo($"Plugin {Name} ({Id}) has loaded!");


### PR DESCRIPTION
### Summary of Changes

Provide a quick summary of the change. What problem is being addressed and how?

Some things (notably Language) are not ready when plugins Awake and are when plugins Start, so we should consider changing the default in order to stem the flow of dev-support questions.

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [x ] There is another change actively WIP that will update the version (link issue or PR here - #69 )
  * [ ] This PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  