### PR TITLE
Add a separate plugin folder macro in silksongpath.props

### DIFF
--- a/Silksong.Modding.Templates.Tests/SilksongPathTest.cs
+++ b/Silksong.Modding.Templates.Tests/SilksongPathTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using DiffEngine;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Silksong.Modding.Templates.Tests.ScenarioModel;
 using Xunit.Abstractions;

--- a/Silksong.Modding.Templates.Tests/SilksongPluginTest.cs
+++ b/Silksong.Modding.Templates.Tests/SilksongPluginTest.cs
@@ -1,3 +1,4 @@
+using DiffEngine;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Silksong.Modding.Templates.Tests.ScenarioModel;
@@ -27,6 +28,8 @@ public class SilksongPluginTest(ITestOutputHelper output)
                 "thunderstore/icon.png"
             ),
         };
+        // The volume of files in a given change is generally much higher than the default 5 for this test suite
+        DiffRunner.MaxInstancesToLaunch(20);
 
         VerificationEngine engine = new(logger);
 

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongpath.CustomPath.verified/silksongpath/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongpath.CustomPath.verified/silksongpath/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>./My/Local/Path</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongpath.Default.verified/silksongpath/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongpath.Default.verified/silksongpath/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>C:/Program Files (x86)/Steam/steamapps/common/Hollow Knight Silksong</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>C:/Program Files (x86)/Steam/steamapps/common/Hollow Knight Silksong</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/SilksongTemplateTester.csproj
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/SilksongTemplateTester.csproj
@@ -17,9 +17,9 @@
     <!-- CI environment variable is automatically set by GitHub actions -->
     <RestoreLockedMode Condition="'$(CI)' == 'true'">True</RestoreLockedMode>
 
-    <!--Allow access of private members at runtime.-->
+    <!-- Allow access of private members at runtime -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <!-- Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however. -->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -59,11 +59,15 @@
     <PropertyGroup>
       <ThunderstoreDir>$(ProjectDir)/thunderstore</ThunderstoreDir>
     </PropertyGroup>
+
+    <!-- Local install -->
     <Copy
       SourceFiles="@(Binaries)"
-      DestinationFolder="$(SilksongFolder)/BepInEx/plugins/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
-      Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')"
+      DestinationFolder="$(SilksongPluginsFolder)/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
+      Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')"
     />
+
+    <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
     <MakeDir Directories="$(ThunderstoreDir)/temp" />
     <Copy

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>C:/Program Files (x86)/Steam/steamapps/common/Hollow Knight Silksong</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/SilksongTemplateTester.csproj
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/SilksongTemplateTester.csproj
@@ -13,9 +13,9 @@
     <!-- Ignore warning about processor architecture mismatch with PlayMaker ConditionalExpression -->
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
 
-    <!--Allow access of private members at runtime.-->
+    <!-- Allow access of private members at runtime -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <!-- Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however. -->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -55,11 +55,15 @@
     <PropertyGroup>
       <ThunderstoreDir>$(ProjectDir)/thunderstore</ThunderstoreDir>
     </PropertyGroup>
+
+    <!-- Local install -->
     <Copy
       SourceFiles="@(Binaries)"
-      DestinationFolder="$(SilksongFolder)/BepInEx/plugins/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
-      Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')"
+      DestinationFolder="$(SilksongPluginsFolder)/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
+      Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')"
     />
+
+    <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
     <MakeDir Directories="$(ThunderstoreDir)/temp" />
     <Copy

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/Silksong.TemplateTester.csproj
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/Silksong.TemplateTester.csproj
@@ -17,9 +17,9 @@
     <!-- CI environment variable is automatically set by GitHub actions -->
     <RestoreLockedMode Condition="'$(CI)' == 'true'">True</RestoreLockedMode>
 
-    <!--Allow access of private members at runtime.-->
+    <!-- Allow access of private members at runtime -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <!-- Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however. -->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -59,11 +59,15 @@
     <PropertyGroup>
       <ThunderstoreDir>$(ProjectDir)/thunderstore</ThunderstoreDir>
     </PropertyGroup>
+
+    <!-- Local install -->
     <Copy
       SourceFiles="@(Binaries)"
-      DestinationFolder="$(SilksongFolder)/BepInEx/plugins/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
-      Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')"
+      DestinationFolder="$(SilksongPluginsFolder)/MyUsername-$(AssemblyTitle)/%(Binaries.LocalDir)"
+      Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')"
     />
+
+    <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
     <MakeDir Directories="$(ThunderstoreDir)/temp" />
     <Copy

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>C:/Program Files (x86)/Steam/steamapps/common/Hollow Knight Silksong</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/SilksongPath.props
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/SilksongPath.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>C:/Program Files (x86)/Steam/steamapps/common/Hollow Knight Silksong</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/SilksongTemplateTester.csproj
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/SilksongTemplateTester.csproj
@@ -17,9 +17,9 @@
     <!-- CI environment variable is automatically set by GitHub actions -->
     <RestoreLockedMode Condition="'$(CI)' == 'true'">True</RestoreLockedMode>
 
-    <!--Allow access of private members at runtime.-->
+    <!-- Allow access of private members at runtime -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <!-- Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however. -->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -59,11 +59,15 @@
     <PropertyGroup>
       <ThunderstoreDir>$(ProjectDir)/thunderstore</ThunderstoreDir>
     </PropertyGroup>
+
+    <!-- Local install -->
     <Copy
       SourceFiles="@(Binaries)"
-      DestinationFolder="$(SilksongFolder)/BepInEx/plugins/my_username-$(AssemblyTitle)/%(Binaries.LocalDir)"
-      Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')"
+      DestinationFolder="$(SilksongPluginsFolder)/my_username-$(AssemblyTitle)/%(Binaries.LocalDir)"
+      Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')"
     />
+
+    <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
     <MakeDir Directories="$(ThunderstoreDir)/temp" />
     <Copy

--- a/Silksong.Modding.Templates/content/SilksongPath/SilksongPath.props
+++ b/Silksong.Modding.Templates/content/SilksongPath/SilksongPath.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>SilksongInstallPath</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>

--- a/Silksong.Modding.Templates/content/SilksongPlugin/Silksong.Plugin.1.csproj
+++ b/Silksong.Modding.Templates/content/SilksongPlugin/Silksong.Plugin.1.csproj
@@ -19,9 +19,9 @@
     <RestoreLockedMode Condition="'$(CI)' == 'true'">True</RestoreLockedMode>
 
     <!--#endif -->
-    <!--Allow access of private members at runtime.-->
+    <!-- Allow access of private members at runtime -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!--Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however.-->
+    <!-- Shortens and anonymizes paths in debug symbols relative to the project directory. Breakpoints will not work, however. -->
     <PathMap Condition="'$(Configuration)' == 'Release'">$(MSBuildProjectDirectory)=/</PathMap>
 
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -67,11 +67,15 @@
     <PropertyGroup>
       <ThunderstoreDir>$(ProjectDir)/thunderstore</ThunderstoreDir>
     </PropertyGroup>
+
+    <!-- Local install -->
     <Copy
       SourceFiles="@(Binaries)"
-      DestinationFolder="$(SilksongFolder)/BepInEx/plugins/ThunderstoreUserName-$(AssemblyTitle)/%(Binaries.LocalDir)"
-      Condition="'$(SilksongFolder)' != '' And Exists('$(SilksongFolder)')"
+      DestinationFolder="$(SilksongPluginsFolder)/ThunderstoreUserName-$(AssemblyTitle)/%(Binaries.LocalDir)"
+      Condition="'$(SilksongPluginsFolder)' != '' And Exists('$(SilksongPluginsFolder)')"
     />
+
+    <!-- Thunderstore packaging -->
     <RemoveDir Directories="$(ThunderstoreDir)/temp;$(ThunderstoreDir)/dist" />
     <MakeDir Directories="$(ThunderstoreDir)/temp" />
     <Copy

--- a/Silksong.Modding.Templates/content/SilksongPlugin/SilksongPath.props
+++ b/Silksong.Modding.Templates/content/SilksongPlugin/SilksongPath.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
     <SilksongFolder>SilksongInstallPath</SilksongFolder>
+    <!-- If you use a mod manager rather than manually installing BepInEx, this should be a profile directory for that mod manager. -->
+    <SilksongPluginsFolder>$(SilksongFolder)/BepInEx/plugins</SilksongPluginsFolder>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Summary of Changes

This brings in some changes to support https://github.com/silksong-modding/Silksong.ModMenu/pull/5 and ultimately #30 

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [x] There is another change actively WIP that will update the version (#69 )
  * [ ] This PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  