### PR TITLE
Add groups for content dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,16 @@ updates:
       - dependency-name: UnityEngine.Modules
     schedule:
       interval: daily
+    groups:
+      content-deps:
+        patterns: 
+          - *
   - directories:
       - Silksong.Modding.Templates/content/**/.github/workflows/
     package-ecosystem: github-actions
     schedule:
       interval: daily
+    groups:
+      content-deps:
+        patterns:
+          - *


### PR DESCRIPTION
### Summary of Changes

This makes it easier to manage the acceptance test changes when multiple dependencies update


### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [x] This PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  