### PR TITLE
Intelligently skip nuget and thunderstore jobs when secret is absent

### DIFF
--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/.github/workflows/build-publish.yml
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.Minimal.verified/silksongplugin/.github/workflows/build-publish.yml
@@ -78,16 +78,20 @@ jobs:
   release-thunderstore:
     needs:
       - build
+      - secret-check
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-thunderstore-secret == 'true' &&
       (
-        github.event_name == 'push' &&
-        needs.build.outputs.allow-release == 'true' &&
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_thunderstore == 'true'
+        (
+          github.event_name == 'push' &&
+          needs.build.outputs.allow-release == 'true' &&
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_thunderstore == 'true'
+        )
       )
     # Do not substitute your Thunderstore API key in this workflow! Instead, add a secret to your repository.
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -108,7 +112,6 @@ jobs:
         name: mod-bundle
         path: thunderstore/dist
     - name: Publish to Thunderstore
-      if: env.THUNDERSTORE_API_KEY != ''
       run: |-
         dotnet tcli publish \
           --config-path thunderstore/thunderstore.toml \
@@ -119,16 +122,20 @@ jobs:
   release-nuget:
     needs:
       - build
+      - secret-check 
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-nuget-secret == 'true' && 
       (
-        github.event_name == 'push' && 
-        needs.build.outputs.allow-release == 'true' && 
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_nuget == 'true'
+        (
+          github.event_name == 'push' && 
+          needs.build.outputs.allow-release == 'true' && 
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_nuget == 'true'
+        )
       )
     # Do not substitute your NuGet API key in this workflow! Instead, add a secret to your repository
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -146,7 +153,6 @@ jobs:
         name: nuget
         path: nuget/
     - name: Publish to NuGet
-      if: env.NUGET_API_KEY != ''
       run: |-
         dotnet nuget push nuget/*.nupkg \
           --api-key $NUGET_API_KEY \
@@ -177,3 +183,11 @@ jobs:
           Build attested at ${{ needs.build.outputs.attestation-url }}
         files: |
           thunderstore/dist/*.zip
+
+  secret-check:
+    runs-on: ubuntu-latest
+    outputs:
+      has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
+      has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
+    steps:
+      - run: echo no-op

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/.github/workflows/build-publish.yml
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.SpecificSilksongVersion.verified/silksongplugin/.github/workflows/build-publish.yml
@@ -78,16 +78,20 @@ jobs:
   release-thunderstore:
     needs:
       - build
+      - secret-check
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-thunderstore-secret == 'true' &&
       (
-        github.event_name == 'push' &&
-        needs.build.outputs.allow-release == 'true' &&
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_thunderstore == 'true'
+        (
+          github.event_name == 'push' &&
+          needs.build.outputs.allow-release == 'true' &&
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_thunderstore == 'true'
+        )
       )
     # Do not substitute your Thunderstore API key in this workflow! Instead, add a secret to your repository.
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -108,7 +112,6 @@ jobs:
         name: mod-bundle
         path: thunderstore/dist
     - name: Publish to Thunderstore
-      if: env.THUNDERSTORE_API_KEY != ''
       run: |-
         dotnet tcli publish \
           --config-path thunderstore/thunderstore.toml \
@@ -119,16 +122,20 @@ jobs:
   release-nuget:
     needs:
       - build
+      - secret-check 
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-nuget-secret == 'true' && 
       (
-        github.event_name == 'push' && 
-        needs.build.outputs.allow-release == 'true' && 
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_nuget == 'true'
+        (
+          github.event_name == 'push' && 
+          needs.build.outputs.allow-release == 'true' && 
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_nuget == 'true'
+        )
       )
     # Do not substitute your NuGet API key in this workflow! Instead, add a secret to your repository
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -146,7 +153,6 @@ jobs:
         name: nuget
         path: nuget/
     - name: Publish to NuGet
-      if: env.NUGET_API_KEY != ''
       run: |-
         dotnet nuget push nuget/*.nupkg \
           --api-key $NUGET_API_KEY \
@@ -177,3 +183,11 @@ jobs:
           Build attested at ${{ needs.build.outputs.attestation-url }}
         files: |
           thunderstore/dist/*.zip
+
+  secret-check:
+    runs-on: ubuntu-latest
+    outputs:
+      has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
+      has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
+    steps:
+      - run: echo no-op

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/.github/workflows/build-publish.yml
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.StrippedName.verified/silksongplugin/.github/workflows/build-publish.yml
@@ -78,16 +78,20 @@ jobs:
   release-thunderstore:
     needs:
       - build
+      - secret-check
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-thunderstore-secret == 'true' &&
       (
-        github.event_name == 'push' &&
-        needs.build.outputs.allow-release == 'true' &&
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_thunderstore == 'true'
+        (
+          github.event_name == 'push' &&
+          needs.build.outputs.allow-release == 'true' &&
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_thunderstore == 'true'
+        )
       )
     # Do not substitute your Thunderstore API key in this workflow! Instead, add a secret to your repository.
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -108,7 +112,6 @@ jobs:
         name: mod-bundle
         path: thunderstore/dist
     - name: Publish to Thunderstore
-      if: env.THUNDERSTORE_API_KEY != ''
       run: |-
         dotnet tcli publish \
           --config-path thunderstore/thunderstore.toml \
@@ -119,16 +122,20 @@ jobs:
   release-nuget:
     needs:
       - build
+      - secret-check 
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-nuget-secret == 'true' && 
       (
-        github.event_name == 'push' && 
-        needs.build.outputs.allow-release == 'true' && 
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_nuget == 'true'
+        (
+          github.event_name == 'push' && 
+          needs.build.outputs.allow-release == 'true' && 
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_nuget == 'true'
+        )
       )
     # Do not substitute your NuGet API key in this workflow! Instead, add a secret to your repository
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -146,7 +153,6 @@ jobs:
         name: nuget
         path: nuget/
     - name: Publish to NuGet
-      if: env.NUGET_API_KEY != ''
       run: |-
         dotnet nuget push nuget/*.nupkg \
           --api-key $NUGET_API_KEY \
@@ -177,3 +183,11 @@ jobs:
           Build attested at ${{ needs.build.outputs.attestation-url }}
         files: |
           thunderstore/dist/*.zip
+
+  secret-check:
+    runs-on: ubuntu-latest
+    outputs:
+      has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
+      has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
+    steps:
+      - run: echo no-op

--- a/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/.github/workflows/build-publish.yml
+++ b/Silksong.Modding.Templates.Tests/Snapshots/SnapshotTest.silksongplugin.ThunderstoreOverride.verified/silksongplugin/.github/workflows/build-publish.yml
@@ -78,16 +78,20 @@ jobs:
   release-thunderstore:
     needs:
       - build
+      - secret-check
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-thunderstore-secret == 'true' &&
       (
-        github.event_name == 'push' &&
-        needs.build.outputs.allow-release == 'true' &&
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_thunderstore == 'true'
+        (
+          github.event_name == 'push' &&
+          needs.build.outputs.allow-release == 'true' &&
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_thunderstore == 'true'
+        )
       )
     # Do not substitute your Thunderstore API key in this workflow! Instead, add a secret to your repository.
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -108,7 +112,6 @@ jobs:
         name: mod-bundle
         path: thunderstore/dist
     - name: Publish to Thunderstore
-      if: env.THUNDERSTORE_API_KEY != ''
       run: |-
         dotnet tcli publish \
           --config-path thunderstore/thunderstore.toml \
@@ -119,16 +122,20 @@ jobs:
   release-nuget:
     needs:
       - build
+      - secret-check 
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-nuget-secret == 'true' && 
       (
-        github.event_name == 'push' && 
-        needs.build.outputs.allow-release == 'true' && 
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_nuget == 'true'
+        (
+          github.event_name == 'push' && 
+          needs.build.outputs.allow-release == 'true' && 
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_nuget == 'true'
+        )
       )
     # Do not substitute your NuGet API key in this workflow! Instead, add a secret to your repository
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -146,7 +153,6 @@ jobs:
         name: nuget
         path: nuget/
     - name: Publish to NuGet
-      if: env.NUGET_API_KEY != ''
       run: |-
         dotnet nuget push nuget/*.nupkg \
           --api-key $NUGET_API_KEY \
@@ -177,3 +183,11 @@ jobs:
           Build attested at ${{ needs.build.outputs.attestation-url }}
         files: |
           thunderstore/dist/*.zip
+
+  secret-check:
+    runs-on: ubuntu-latest
+    outputs:
+      has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
+      has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
+    steps:
+      - run: echo no-op

--- a/Silksong.Modding.Templates/content/SilksongPlugin/.github/workflows/build-publish.yml
+++ b/Silksong.Modding.Templates/content/SilksongPlugin/.github/workflows/build-publish.yml
@@ -78,16 +78,20 @@ jobs:
   release-thunderstore:
     needs:
       - build
+      - secret-check
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-thunderstore-secret == 'true' &&
       (
-        github.event_name == 'push' &&
-        needs.build.outputs.allow-release == 'true' &&
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_thunderstore == 'true'
+        (
+          github.event_name == 'push' &&
+          needs.build.outputs.allow-release == 'true' &&
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_thunderstore == 'true'
+        )
       )
     # Do not substitute your Thunderstore API key in this workflow! Instead, add a secret to your repository.
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -108,7 +112,6 @@ jobs:
         name: mod-bundle
         path: thunderstore/dist
     - name: Publish to Thunderstore
-      if: env.THUNDERSTORE_API_KEY != ''
       run: |-
         dotnet tcli publish \
           --config-path thunderstore/thunderstore.toml \
@@ -119,16 +122,20 @@ jobs:
   release-nuget:
     needs:
       - build
+      - secret-check 
     runs-on: ubuntu-latest
     if: |
+      needs.secret-check.outputs.has-nuget-secret == 'true' && 
       (
-        github.event_name == 'push' && 
-        needs.build.outputs.allow-release == 'true' && 
-        needs.build.outputs.is-new-version == 'true'
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.force_nuget == 'true'
+        (
+          github.event_name == 'push' && 
+          needs.build.outputs.allow-release == 'true' && 
+          needs.build.outputs.is-new-version == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.force_nuget == 'true'
+        )
       )
     # Do not substitute your NuGet API key in this workflow! Instead, add a secret to your repository
     # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
@@ -146,7 +153,6 @@ jobs:
         name: nuget
         path: nuget/
     - name: Publish to NuGet
-      if: env.NUGET_API_KEY != ''
       run: |-
         dotnet nuget push nuget/*.nupkg \
           --api-key $NUGET_API_KEY \
@@ -177,3 +183,11 @@ jobs:
           Build attested at ${{ needs.build.outputs.attestation-url }}
         files: |
           thunderstore/dist/*.zip
+
+  secret-check:
+    runs-on: ubuntu-latest
+    outputs:
+      has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
+      has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
+    steps:
+      - run: echo no-op


### PR DESCRIPTION
### Summary of Changes

Due to gh limitations we currently run the full job for nuget and thunderstore publishes and only skip the publishing step if the secret is not configured, which can give the false sense that the publish actually happened. This fixes that by introducing a small job to check for secret presence and using that as an indicator to skip publishing jobs.

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [x] There is another change actively WIP that will update the version (link issue or PR here) #21 
  * [ ] This PR does not change the template content/config.
* If updating to support a new Silksong version only:
  * [ ] I have updated template.json to include the new game version.
  * [ ] I have installed the updated template locally and ensured that a plugin created for the new game version builds out of the box.
  